### PR TITLE
Funclight colon

### DIFF
--- a/src/go/ast/ast.go
+++ b/src/go/ast/ast.go
@@ -323,6 +323,13 @@ type (
 		Body *BlockStmt // function body
 	}
 
+	ShortFuncLit struct {
+		Type   *FuncType
+		Body   *BlockStmt
+		Expr   []Expr
+		Rparen token.Pos
+	}
+
 	// A CompositeLit node represents a composite literal.
 	CompositeLit struct {
 		Type       Expr      // literal type; or nil
@@ -489,11 +496,12 @@ type (
 
 // Pos and End implementations for expression/type nodes.
 
-func (x *BadExpr) Pos() token.Pos  { return x.From }
-func (x *Ident) Pos() token.Pos    { return x.NamePos }
-func (x *Ellipsis) Pos() token.Pos { return x.Ellipsis }
-func (x *BasicLit) Pos() token.Pos { return x.ValuePos }
-func (x *FuncLit) Pos() token.Pos  { return x.Type.Pos() }
+func (x *BadExpr) Pos() token.Pos      { return x.From }
+func (x *Ident) Pos() token.Pos        { return x.NamePos }
+func (x *Ellipsis) Pos() token.Pos     { return x.Ellipsis }
+func (x *BasicLit) Pos() token.Pos     { return x.ValuePos }
+func (x *FuncLit) Pos() token.Pos      { return x.Type.Pos() }
+func (x *ShortFuncLit) Pos() token.Pos { return x.Type.Pos() }
 func (x *CompositeLit) Pos() token.Pos {
 	if x.Type != nil {
 		return x.Type.Pos()
@@ -531,8 +539,20 @@ func (x *Ellipsis) End() token.Pos {
 	}
 	return x.Ellipsis + 3 // len("...")
 }
-func (x *BasicLit) End() token.Pos       { return token.Pos(int(x.ValuePos) + len(x.Value)) }
-func (x *FuncLit) End() token.Pos        { return x.Body.End() }
+func (x *BasicLit) End() token.Pos { return token.Pos(int(x.ValuePos) + len(x.Value)) }
+func (x *FuncLit) End() token.Pos  { return x.Body.End() }
+
+func (x *ShortFuncLit) End() token.Pos {
+	switch {
+	case x.Body != nil:
+		return x.Body.End()
+	case x.Rparen.IsValid():
+		return x.Rparen
+	default:
+		return x.Expr[0].End()
+	}
+}
+
 func (x *CompositeLit) End() token.Pos   { return x.Rbrace + 1 }
 func (x *ParenExpr) End() token.Pos      { return x.Rparen + 1 }
 func (x *SelectorExpr) End() token.Pos   { return x.Sel.End() }
@@ -564,6 +584,7 @@ func (*Ident) exprNode()          {}
 func (*Ellipsis) exprNode()       {}
 func (*BasicLit) exprNode()       {}
 func (*FuncLit) exprNode()        {}
+func (*ShortFuncLit) exprNode()   {}
 func (*CompositeLit) exprNode()   {}
 func (*ParenExpr) exprNode()      {}
 func (*SelectorExpr) exprNode()   {}

--- a/src/go/parser/parser.go
+++ b/src/go/parser/parser.go
@@ -1450,30 +1450,30 @@ func (p *parser) parseFuncTypeOrLit() ast.Expr {
 		return typ
 	}
 
-	lit := &ast.FuncLit{Type: typ}
-
 	p.exprLev++
 
+	var expr ast.Expr
 	if short {
-		lit.Colon = p.pos
+		lit := &ast.ShortFuncLit{Type: typ}
 
 		switch p.next(); p.tok {
 		case token.LBRACE:
 			lit.Body = p.parseBody()
 		case token.LPAREN:
 			lit.Expr = p.parseList(true)
-			lit.ExprEnd = p.expect(token.RPAREN)
+			lit.Rparen = p.expect(token.RPAREN)
 		default:
 			lit.Expr = []ast.Expr{p.parseExpr()}
-			lit.ExprEnd = lit.Expr[0].End()
 		}
+
+		expr = lit
 	} else {
-		lit.Body = p.parseBody()
+		expr = &ast.FuncLit{Type: typ, Body: p.parseBody()}
 	}
 
 	p.exprLev--
 
-	return lit
+	return expr
 }
 
 // parseOperand may return an expression or a raw type (incl. array

--- a/src/go/parser/parser.go
+++ b/src/go/parser/parser.go
@@ -21,7 +21,6 @@ import (
 	"go/build/constraint"
 	"go/scanner"
 	"go/token"
-	"math"
 	"strings"
 )
 
@@ -68,6 +67,8 @@ type parser struct {
 	nestLev int
 }
 
+const preferExpr = -10
+
 func (p *parser) init(file *token.File, src []byte, mode Mode) {
 	p.file = file
 	eh := func(pos token.Position, msg string) { p.errors.Add(pos, msg) }
@@ -76,7 +77,7 @@ func (p *parser) init(file *token.File, src []byte, mode Mode) {
 	p.top = true
 	p.mode = mode
 	p.trace = mode&Trace != 0 // for convenience (p.trace is used frequently)
-	p.preferTypeAtExprLev = math.MinInt
+	p.preferTypeAtExprLev = preferExpr
 	p.next()
 }
 
@@ -2114,7 +2115,7 @@ func (p *parser) parseIfHeader() (init ast.Stmt, cond ast.Expr) {
 	// p.tok != token.LBRACE
 
 	prevLev, prevPreferType := p.exprLev, p.preferTypeAtExprLev
-	p.exprLev, p.preferTypeAtExprLev = -1, math.MinInt
+	p.exprLev, p.preferTypeAtExprLev = -1, preferExpr
 
 	if p.tok != token.SEMICOLON {
 		// accept potential variable declaration but complain
@@ -2264,7 +2265,7 @@ func (p *parser) parseSwitchStmt() ast.Stmt {
 	var s1, s2 ast.Stmt
 	if p.tok != token.LBRACE {
 		prevLev, prevPreferType := p.exprLev, p.preferTypeAtExprLev
-		p.exprLev, p.preferTypeAtExprLev = -1, math.MinInt
+		p.exprLev, p.preferTypeAtExprLev = -1, preferExpr
 
 		if p.tok != token.SEMICOLON {
 			s2, _ = p.parseSimpleStmt(basic)
@@ -2391,7 +2392,7 @@ func (p *parser) parseForStmt() ast.Stmt {
 	var isRange bool
 	if p.tok != token.LBRACE {
 		prevLev, prevPreferType := p.exprLev, p.preferTypeAtExprLev
-		p.exprLev, p.preferTypeAtExprLev = -1, math.MinInt
+		p.exprLev, p.preferTypeAtExprLev = -1, preferExpr
 		if p.tok != token.SEMICOLON {
 			if p.tok == token.RANGE {
 				// "for range x" (nil lhs in assignment)

--- a/src/go/parser/parser.go
+++ b/src/go/parser/parser.go
@@ -21,6 +21,7 @@ import (
 	"go/build/constraint"
 	"go/scanner"
 	"go/token"
+	"math"
 	"strings"
 )
 
@@ -58,6 +59,8 @@ type parser struct {
 	exprLev int  // < 0: in control clause, >= 0: in expression
 	inRhs   bool // if set, the parser is parsing a rhs expression
 
+	preferTypeAtExprLev int
+
 	imports []*ast.ImportSpec // list of imports
 
 	// nestLev is used to track and limit the recursion depth
@@ -73,6 +76,7 @@ func (p *parser) init(file *token.File, src []byte, mode Mode) {
 	p.top = true
 	p.mode = mode
 	p.trace = mode&Trace != 0 // for convenience (p.trace is used frequently)
+	p.preferTypeAtExprLev = math.MinInt
 	p.next()
 }
 
@@ -493,34 +497,26 @@ func (p *parser) parseIdentList() (list []*ast.Ident) {
 // Common productions
 
 // If lhs is set, result list elements which are identifiers are not resolved.
-func (p *parser) parseExprList(preferType bool) (list []ast.Expr) {
+func (p *parser) parseExprList() (list []ast.Expr) {
 	if p.trace {
 		defer un(trace(p, "ExpressionList"))
 	}
 
-	list = append(list, p.parseExpr0(preferType))
+	list = append(list, p.parseExpr())
 	for p.tok == token.COMMA {
 		p.next()
-		list = append(list, p.parseExpr0(preferType))
+		list = append(list, p.parseExpr())
 	}
 
 	return
 }
 
-func (p *parser) parseList0(inRhs, preferType bool) []ast.Expr {
+func (p *parser) parseList(inRhs bool) []ast.Expr {
 	old := p.inRhs
 	p.inRhs = inRhs
-	list := p.parseExprList(preferType)
+	list := p.parseExprList()
 	p.inRhs = old
 	return list
-}
-
-func (p *parser) parseList(inRhs bool) []ast.Expr {
-	return p.parseList0(inRhs, false)
-}
-
-func (p *parser) parseTypeList(inRhs bool) []ast.Expr {
-	return p.parseList0(inRhs, true)
 }
 
 // ----------------------------------------------------------------------------
@@ -1441,7 +1437,7 @@ func (p *parser) parseBlockStmt() *ast.BlockStmt {
 // ----------------------------------------------------------------------------
 // Expressions
 
-func (p *parser) parseFuncTypeOrLit(preferType bool) ast.Expr {
+func (p *parser) parseFuncTypeOrLit() ast.Expr {
 	if p.trace {
 		defer un(trace(p, "FuncTypeOrLit"))
 	}
@@ -1449,7 +1445,7 @@ func (p *parser) parseFuncTypeOrLit(preferType bool) ast.Expr {
 	typ := p.parseFuncType()
 	short := p.tok == token.COLON
 
-	if (p.tok != token.LBRACE && !short) || preferType {
+	if (p.tok != token.LBRACE && !short) || (p.exprLev == p.preferTypeAtExprLev) {
 		// function type only
 		return typ
 	}
@@ -1482,7 +1478,7 @@ func (p *parser) parseFuncTypeOrLit(preferType bool) ast.Expr {
 
 // parseOperand may return an expression or a raw type (incl. array
 // types of the form [...]T). Callers must verify the result.
-func (p *parser) parseOperand(preferType bool) ast.Expr {
+func (p *parser) parseOperand() ast.Expr {
 	if p.trace {
 		defer un(trace(p, "Operand"))
 	}
@@ -1510,7 +1506,7 @@ func (p *parser) parseOperand(preferType bool) ast.Expr {
 		return &ast.ParenExpr{Lparen: lparen, X: x, Rparen: rparen}
 
 	case token.FUNC:
-		return p.parseFuncTypeOrLit(preferType)
+		return p.parseFuncTypeOrLit()
 	}
 
 	if typ := p.tryIdentOrType(); typ != nil { // do not consume trailing type parameters
@@ -1728,13 +1724,13 @@ func (p *parser) parseLiteralValue(typ ast.Expr) ast.Expr {
 	return &ast.CompositeLit{Type: typ, Lbrace: lbrace, Elts: elts, Rbrace: rbrace}
 }
 
-func (p *parser) parsePrimaryExpr(x ast.Expr, preferType bool) ast.Expr {
+func (p *parser) parsePrimaryExpr(x ast.Expr) ast.Expr {
 	if p.trace {
 		defer un(trace(p, "PrimaryExpr"))
 	}
 
 	if x == nil {
-		x = p.parseOperand(preferType)
+		x = p.parseOperand()
 	}
 	// We track the nesting here rather than at the entry for the function,
 	// since it can iteratively produce a nested output, and we want to
@@ -1801,7 +1797,7 @@ func (p *parser) parsePrimaryExpr(x ast.Expr, preferType bool) ast.Expr {
 	}
 }
 
-func (p *parser) parseUnaryExpr(preferType bool) ast.Expr {
+func (p *parser) parseUnaryExpr() ast.Expr {
 	defer decNestLev(incNestLev(p))
 
 	if p.trace {
@@ -1813,7 +1809,7 @@ func (p *parser) parseUnaryExpr(preferType bool) ast.Expr {
 		pos, op := p.pos, p.tok
 		p.next()
 		// Only after tilde can a type still follow.
-		x := p.parseUnaryExpr(preferType && p.tok == token.TILDE)
+		x := p.parseUnaryExpr()
 		return &ast.UnaryExpr{OpPos: pos, Op: op, X: x}
 
 	case token.ARROW:
@@ -1835,7 +1831,7 @@ func (p *parser) parseUnaryExpr(preferType bool) ast.Expr {
 		//   <- (chan type)    =>  (<-chan type)
 		//   <- (chan<- type)  =>  (<-chan (<-type))
 
-		x := p.parseUnaryExpr(preferType)
+		x := p.parseUnaryExpr()
 
 		// determine which case we have
 		if typ, ok := x.(*ast.ChanType); ok {
@@ -1866,11 +1862,11 @@ func (p *parser) parseUnaryExpr(preferType bool) ast.Expr {
 		// pointer type or unary "*" expression
 		pos := p.pos
 		p.next()
-		x := p.parseUnaryExpr(preferType)
+		x := p.parseUnaryExpr()
 		return &ast.StarExpr{Star: pos, X: x}
 	}
 
-	return p.parsePrimaryExpr(nil, preferType)
+	return p.parsePrimaryExpr(nil)
 }
 
 func (p *parser) tokPrec() (token.Token, int) {
@@ -1885,13 +1881,13 @@ func (p *parser) tokPrec() (token.Token, int) {
 // If x is non-nil, it is used as the left operand.
 //
 // TODO(rfindley): parseBinaryExpr has become overloaded. Consider refactoring.
-func (p *parser) parseBinaryExpr(x ast.Expr, prec1 int, preferType bool) ast.Expr {
+func (p *parser) parseBinaryExpr(x ast.Expr, prec1 int) ast.Expr {
 	if p.trace {
 		defer un(trace(p, "BinaryExpr"))
 	}
 
 	if x == nil {
-		x = p.parseUnaryExpr(preferType)
+		x = p.parseUnaryExpr()
 	}
 	// We track the nesting here rather than at the entry for the function,
 	// since it can iteratively produce a nested output, and we want to
@@ -1905,22 +1901,18 @@ func (p *parser) parseBinaryExpr(x ast.Expr, prec1 int, preferType bool) ast.Exp
 			return x
 		}
 		pos := p.expect(op)
-		y := p.parseBinaryExpr(nil, oprec+1, preferType)
+		y := p.parseBinaryExpr(nil, oprec+1)
 		x = &ast.BinaryExpr{X: x, OpPos: pos, Op: op, Y: y}
 	}
 }
 
-func (p *parser) parseExpr0(preferType bool) ast.Expr {
+// The result may be a type or even a raw type ([...]int).
+func (p *parser) parseExpr() ast.Expr {
 	if p.trace {
 		defer un(trace(p, "Expression"))
 	}
 
-	return p.parseBinaryExpr(nil, token.LowestPrec+1, preferType)
-}
-
-// The result may be a type or even a raw type ([...]int).
-func (p *parser) parseExpr() ast.Expr {
-	return p.parseExpr0(false)
+	return p.parseBinaryExpr(nil, token.LowestPrec+1)
 }
 
 func (p *parser) parseRhs() ast.Expr {
@@ -2121,8 +2113,8 @@ func (p *parser) parseIfHeader() (init ast.Stmt, cond ast.Expr) {
 	}
 	// p.tok != token.LBRACE
 
-	prevLev := p.exprLev
-	p.exprLev = -1
+	prevLev, prevPreferType := p.exprLev, p.preferTypeAtExprLev
+	p.exprLev, p.preferTypeAtExprLev = -1, math.MinInt
 
 	if p.tok != token.SEMICOLON {
 		// accept potential variable declaration but complain
@@ -2169,7 +2161,8 @@ func (p *parser) parseIfHeader() (init ast.Stmt, cond ast.Expr) {
 		cond = &ast.BadExpr{From: p.pos, To: p.pos}
 	}
 
-	p.exprLev = prevLev
+	p.exprLev, p.preferTypeAtExprLev = prevLev, prevPreferType
+
 	return
 }
 
@@ -2207,12 +2200,7 @@ func (p *parser) parseIfStmt() *ast.IfStmt {
 
 func (p *parser) parseCaseClause(typeSwitch bool) *ast.CaseClause {
 	if p.trace {
-		name := "CaseClause"
-		if typeSwitch {
-			name = "TypeCaseClause"
-		}
-
-		defer un(trace(p, name))
+		defer un(trace(p, "CaseClause"))
 	}
 
 	pos := p.pos
@@ -2220,10 +2208,15 @@ func (p *parser) parseCaseClause(typeSwitch bool) *ast.CaseClause {
 	if p.tok == token.CASE {
 		p.next()
 
+		old := p.preferTypeAtExprLev
 		if typeSwitch {
-			list = p.parseTypeList(true)
-		} else {
-			list = p.parseList(true)
+			p.preferTypeAtExprLev = p.exprLev
+		}
+
+		list = p.parseList(true)
+
+		if typeSwitch {
+			p.preferTypeAtExprLev = old
 		}
 	} else {
 		p.expect(token.DEFAULT)
@@ -2270,8 +2263,9 @@ func (p *parser) parseSwitchStmt() ast.Stmt {
 
 	var s1, s2 ast.Stmt
 	if p.tok != token.LBRACE {
-		prevLev := p.exprLev
-		p.exprLev = -1
+		prevLev, prevPreferType := p.exprLev, p.preferTypeAtExprLev
+		p.exprLev, p.preferTypeAtExprLev = -1, math.MinInt
+
 		if p.tok != token.SEMICOLON {
 			s2, _ = p.parseSimpleStmt(basic)
 		}
@@ -2295,7 +2289,8 @@ func (p *parser) parseSwitchStmt() ast.Stmt {
 				s2, _ = p.parseSimpleStmt(basic)
 			}
 		}
-		p.exprLev = prevLev
+
+		p.exprLev, p.preferTypeAtExprLev = prevLev, prevPreferType
 	}
 
 	typeSwitch := p.isTypeSwitchGuard(s2)
@@ -2395,8 +2390,8 @@ func (p *parser) parseForStmt() ast.Stmt {
 	var s1, s2, s3 ast.Stmt
 	var isRange bool
 	if p.tok != token.LBRACE {
-		prevLev := p.exprLev
-		p.exprLev = -1
+		prevLev, prevPreferType := p.exprLev, p.preferTypeAtExprLev
+		p.exprLev, p.preferTypeAtExprLev = -1, math.MinInt
 		if p.tok != token.SEMICOLON {
 			if p.tok == token.RANGE {
 				// "for range x" (nil lhs in assignment)
@@ -2421,7 +2416,7 @@ func (p *parser) parseForStmt() ast.Stmt {
 				s3, _ = p.parseSimpleStmt(basic)
 			}
 		}
-		p.exprLev = prevLev
+		p.exprLev, p.preferTypeAtExprLev = prevLev, prevPreferType
 	}
 
 	body := p.parseBlockStmt()
@@ -2667,8 +2662,8 @@ func (p *parser) parseTypeSpec(doc *ast.CommentGroup, _ token.Token, _ int) ast.
 				// the call sequence we would get by passing in name
 				// to parser.expr, and pass in name to parsePrimaryExpr.
 				p.exprLev++
-				lhs := p.parsePrimaryExpr(x, false)
-				x = p.parseBinaryExpr(lhs, token.LowestPrec+1, false)
+				lhs := p.parsePrimaryExpr(x)
+				x = p.parseBinaryExpr(lhs, token.LowestPrec+1)
 				p.exprLev--
 			}
 			// Analyze expression x. If we can split x into a type parameter

--- a/src/go/parser/parser.go
+++ b/src/go/parser/parser.go
@@ -21,6 +21,7 @@ import (
 	"go/build/constraint"
 	"go/scanner"
 	"go/token"
+	"slices"
 	"strings"
 )
 
@@ -1455,6 +1456,14 @@ func (p *parser) parseFuncTypeOrLit() ast.Expr {
 
 	var expr ast.Expr
 	if short {
+		allType := !slices.ContainsFunc(typ.Params.List, func(f *ast.Field) bool { return len(f.Names) > 0 })
+		if allType {
+			for _, f := range typ.Params.List {
+				f.Names = []*ast.Ident{f.Type.(*ast.Ident)}
+				f.Type = nil
+			}
+		}
+
 		lit := &ast.ShortFuncLit{Type: typ}
 
 		switch p.next(); p.tok {

--- a/src/go/parser/parser.go
+++ b/src/go/parser/parser.go
@@ -493,26 +493,34 @@ func (p *parser) parseIdentList() (list []*ast.Ident) {
 // Common productions
 
 // If lhs is set, result list elements which are identifiers are not resolved.
-func (p *parser) parseExprList() (list []ast.Expr) {
+func (p *parser) parseExprList(preferType bool) (list []ast.Expr) {
 	if p.trace {
 		defer un(trace(p, "ExpressionList"))
 	}
 
-	list = append(list, p.parseExpr())
+	list = append(list, p.parseExpr0(preferType))
 	for p.tok == token.COMMA {
 		p.next()
-		list = append(list, p.parseExpr())
+		list = append(list, p.parseExpr0(preferType))
 	}
 
 	return
 }
 
-func (p *parser) parseList(inRhs bool) []ast.Expr {
+func (p *parser) parseList0(inRhs, preferType bool) []ast.Expr {
 	old := p.inRhs
 	p.inRhs = inRhs
-	list := p.parseExprList()
+	list := p.parseExprList(preferType)
 	p.inRhs = old
 	return list
+}
+
+func (p *parser) parseList(inRhs bool) []ast.Expr {
+	return p.parseList0(inRhs, false)
+}
+
+func (p *parser) parseTypeList(inRhs bool) []ast.Expr {
+	return p.parseList0(inRhs, true)
 }
 
 // ----------------------------------------------------------------------------
@@ -1433,13 +1441,13 @@ func (p *parser) parseBlockStmt() *ast.BlockStmt {
 // ----------------------------------------------------------------------------
 // Expressions
 
-func (p *parser) parseFuncTypeOrLit() ast.Expr {
+func (p *parser) parseFuncTypeOrLit(preferType bool) ast.Expr {
 	if p.trace {
 		defer un(trace(p, "FuncTypeOrLit"))
 	}
 
 	typ := p.parseFuncType()
-	if p.tok != token.LBRACE {
+	if p.tok != token.LBRACE || preferType {
 		// function type only
 		return typ
 	}
@@ -1453,7 +1461,7 @@ func (p *parser) parseFuncTypeOrLit() ast.Expr {
 
 // parseOperand may return an expression or a raw type (incl. array
 // types of the form [...]T). Callers must verify the result.
-func (p *parser) parseOperand() ast.Expr {
+func (p *parser) parseOperand(preferType bool) ast.Expr {
 	if p.trace {
 		defer un(trace(p, "Operand"))
 	}
@@ -1472,13 +1480,16 @@ func (p *parser) parseOperand() ast.Expr {
 		lparen := p.pos
 		p.next()
 		p.exprLev++
+		// preferType is used to resolve ambiguities that the "func():"
+		// syntax may introduce. Wrapping it in parens removes any ambiguity,
+		// therefore preferType is not passed down the call stack anymore.
 		x := p.parseRhs() // types may be parenthesized: (some type)
 		p.exprLev--
 		rparen := p.expect(token.RPAREN)
 		return &ast.ParenExpr{Lparen: lparen, X: x, Rparen: rparen}
 
 	case token.FUNC:
-		return p.parseFuncTypeOrLit()
+		return p.parseFuncTypeOrLit(preferType)
 	}
 
 	if typ := p.tryIdentOrType(); typ != nil { // do not consume trailing type parameters
@@ -1696,13 +1707,13 @@ func (p *parser) parseLiteralValue(typ ast.Expr) ast.Expr {
 	return &ast.CompositeLit{Type: typ, Lbrace: lbrace, Elts: elts, Rbrace: rbrace}
 }
 
-func (p *parser) parsePrimaryExpr(x ast.Expr) ast.Expr {
+func (p *parser) parsePrimaryExpr(x ast.Expr, preferType bool) ast.Expr {
 	if p.trace {
 		defer un(trace(p, "PrimaryExpr"))
 	}
 
 	if x == nil {
-		x = p.parseOperand()
+		x = p.parseOperand(preferType)
 	}
 	// We track the nesting here rather than at the entry for the function,
 	// since it can iteratively produce a nested output, and we want to
@@ -1769,7 +1780,7 @@ func (p *parser) parsePrimaryExpr(x ast.Expr) ast.Expr {
 	}
 }
 
-func (p *parser) parseUnaryExpr() ast.Expr {
+func (p *parser) parseUnaryExpr(preferType bool) ast.Expr {
 	defer decNestLev(incNestLev(p))
 
 	if p.trace {
@@ -1780,7 +1791,8 @@ func (p *parser) parseUnaryExpr() ast.Expr {
 	case token.ADD, token.SUB, token.NOT, token.XOR, token.AND, token.TILDE:
 		pos, op := p.pos, p.tok
 		p.next()
-		x := p.parseUnaryExpr()
+		// Only after tilde can a type still follow.
+		x := p.parseUnaryExpr(preferType && p.tok == token.TILDE)
 		return &ast.UnaryExpr{OpPos: pos, Op: op, X: x}
 
 	case token.ARROW:
@@ -1802,7 +1814,7 @@ func (p *parser) parseUnaryExpr() ast.Expr {
 		//   <- (chan type)    =>  (<-chan type)
 		//   <- (chan<- type)  =>  (<-chan (<-type))
 
-		x := p.parseUnaryExpr()
+		x := p.parseUnaryExpr(preferType)
 
 		// determine which case we have
 		if typ, ok := x.(*ast.ChanType); ok {
@@ -1833,11 +1845,11 @@ func (p *parser) parseUnaryExpr() ast.Expr {
 		// pointer type or unary "*" expression
 		pos := p.pos
 		p.next()
-		x := p.parseUnaryExpr()
+		x := p.parseUnaryExpr(preferType)
 		return &ast.StarExpr{Star: pos, X: x}
 	}
 
-	return p.parsePrimaryExpr(nil)
+	return p.parsePrimaryExpr(nil, preferType)
 }
 
 func (p *parser) tokPrec() (token.Token, int) {
@@ -1852,13 +1864,13 @@ func (p *parser) tokPrec() (token.Token, int) {
 // If x is non-nil, it is used as the left operand.
 //
 // TODO(rfindley): parseBinaryExpr has become overloaded. Consider refactoring.
-func (p *parser) parseBinaryExpr(x ast.Expr, prec1 int) ast.Expr {
+func (p *parser) parseBinaryExpr(x ast.Expr, prec1 int, preferType bool) ast.Expr {
 	if p.trace {
 		defer un(trace(p, "BinaryExpr"))
 	}
 
 	if x == nil {
-		x = p.parseUnaryExpr()
+		x = p.parseUnaryExpr(preferType)
 	}
 	// We track the nesting here rather than at the entry for the function,
 	// since it can iteratively produce a nested output, and we want to
@@ -1872,18 +1884,22 @@ func (p *parser) parseBinaryExpr(x ast.Expr, prec1 int) ast.Expr {
 			return x
 		}
 		pos := p.expect(op)
-		y := p.parseBinaryExpr(nil, oprec+1)
+		y := p.parseBinaryExpr(nil, oprec+1, preferType)
 		x = &ast.BinaryExpr{X: x, OpPos: pos, Op: op, Y: y}
 	}
 }
 
-// The result may be a type or even a raw type ([...]int).
-func (p *parser) parseExpr() ast.Expr {
+func (p *parser) parseExpr0(preferType bool) ast.Expr {
 	if p.trace {
 		defer un(trace(p, "Expression"))
 	}
 
-	return p.parseBinaryExpr(nil, token.LowestPrec+1)
+	return p.parseBinaryExpr(nil, token.LowestPrec+1, preferType)
+}
+
+// The result may be a type or even a raw type ([...]int).
+func (p *parser) parseExpr() ast.Expr {
+	return p.parseExpr0(false)
 }
 
 func (p *parser) parseRhs() ast.Expr {
@@ -2168,16 +2184,26 @@ func (p *parser) parseIfStmt() *ast.IfStmt {
 	return &ast.IfStmt{If: pos, Init: init, Cond: cond, Body: body, Else: else_}
 }
 
-func (p *parser) parseCaseClause() *ast.CaseClause {
+func (p *parser) parseCaseClause(typeSwitch bool) *ast.CaseClause {
 	if p.trace {
-		defer un(trace(p, "CaseClause"))
+		name := "CaseClause"
+		if typeSwitch {
+			name = "TypeCaseClause"
+		}
+
+		defer un(trace(p, name))
 	}
 
 	pos := p.pos
 	var list []ast.Expr
 	if p.tok == token.CASE {
 		p.next()
-		list = p.parseList(true)
+
+		if typeSwitch {
+			list = p.parseTypeList(true)
+		} else {
+			list = p.parseList(true)
+		}
 	} else {
 		p.expect(token.DEFAULT)
 	}
@@ -2255,7 +2281,7 @@ func (p *parser) parseSwitchStmt() ast.Stmt {
 	lbrace := p.expect(token.LBRACE)
 	var list []ast.Stmt
 	for p.tok == token.CASE || p.tok == token.DEFAULT {
-		list = append(list, p.parseCaseClause())
+		list = append(list, p.parseCaseClause(typeSwitch))
 	}
 	rbrace := p.expect(token.RBRACE)
 	p.expectSemi()
@@ -2620,8 +2646,8 @@ func (p *parser) parseTypeSpec(doc *ast.CommentGroup, _ token.Token, _ int) ast.
 				// the call sequence we would get by passing in name
 				// to parser.expr, and pass in name to parsePrimaryExpr.
 				p.exprLev++
-				lhs := p.parsePrimaryExpr(x)
-				x = p.parseBinaryExpr(lhs, token.LowestPrec+1)
+				lhs := p.parsePrimaryExpr(x, false)
+				x = p.parseBinaryExpr(lhs, token.LowestPrec+1, false)
 				p.exprLev--
 			}
 			// Analyze expression x. If we can split x into a type parameter

--- a/src/go/parser/parser.go
+++ b/src/go/parser/parser.go
@@ -1447,16 +1447,37 @@ func (p *parser) parseFuncTypeOrLit(preferType bool) ast.Expr {
 	}
 
 	typ := p.parseFuncType()
-	if p.tok != token.LBRACE || preferType {
+	short := p.tok == token.COLON
+
+	if (p.tok != token.LBRACE && !short) || preferType {
 		// function type only
 		return typ
 	}
 
+	lit := &ast.FuncLit{Type: typ}
+
 	p.exprLev++
-	body := p.parseBody()
+
+	if short {
+		lit.Colon = p.pos
+
+		switch p.next(); p.tok {
+		case token.LBRACE:
+			lit.Body = p.parseBody()
+		case token.LPAREN:
+			lit.Expr = p.parseList(true)
+			lit.ExprEnd = p.expect(token.RPAREN)
+		default:
+			lit.Expr = []ast.Expr{p.parseExpr()}
+			lit.ExprEnd = lit.Expr[0].End()
+		}
+	} else {
+		lit.Body = p.parseBody()
+	}
+
 	p.exprLev--
 
-	return &ast.FuncLit{Type: typ, Body: body}
+	return lit
 }
 
 // parseOperand may return an expression or a raw type (incl. array

--- a/src/go/parser/parser.go
+++ b/src/go/parser/parser.go
@@ -1498,9 +1498,6 @@ func (p *parser) parseOperand() ast.Expr {
 		lparen := p.pos
 		p.next()
 		p.exprLev++
-		// preferType is used to resolve ambiguities that the "func():"
-		// syntax may introduce. Wrapping it in parens removes any ambiguity,
-		// therefore preferType is not passed down the call stack anymore.
 		x := p.parseRhs() // types may be parenthesized: (some type)
 		p.exprLev--
 		rparen := p.expect(token.RPAREN)
@@ -1809,7 +1806,6 @@ func (p *parser) parseUnaryExpr() ast.Expr {
 	case token.ADD, token.SUB, token.NOT, token.XOR, token.AND, token.TILDE:
 		pos, op := p.pos, p.tok
 		p.next()
-		// Only after tilde can a type still follow.
 		x := p.parseUnaryExpr()
 		return &ast.UnaryExpr{OpPos: pos, Op: op, X: x}
 
@@ -2163,7 +2159,6 @@ func (p *parser) parseIfHeader() (init ast.Stmt, cond ast.Expr) {
 	}
 
 	p.exprLev, p.preferTypeAtExprLev = prevLev, prevPreferType
-
 	return
 }
 
@@ -2208,14 +2203,11 @@ func (p *parser) parseCaseClause(typeSwitch bool) *ast.CaseClause {
 	var list []ast.Expr
 	if p.tok == token.CASE {
 		p.next()
-
 		old := p.preferTypeAtExprLev
 		if typeSwitch {
 			p.preferTypeAtExprLev = p.exprLev
 		}
-
 		list = p.parseList(true)
-
 		if typeSwitch {
 			p.preferTypeAtExprLev = old
 		}
@@ -2266,7 +2258,6 @@ func (p *parser) parseSwitchStmt() ast.Stmt {
 	if p.tok != token.LBRACE {
 		prevLev, prevPreferType := p.exprLev, p.preferTypeAtExprLev
 		p.exprLev, p.preferTypeAtExprLev = -1, preferExpr
-
 		if p.tok != token.SEMICOLON {
 			s2, _ = p.parseSimpleStmt(basic)
 		}
@@ -2290,7 +2281,6 @@ func (p *parser) parseSwitchStmt() ast.Stmt {
 				s2, _ = p.parseSimpleStmt(basic)
 			}
 		}
-
 		p.exprLev, p.preferTypeAtExprLev = prevLev, prevPreferType
 	}
 


### PR DESCRIPTION
To remove the switch case ambiguity, the parser is adjusted to prefer just the function type when parsing a function literal at the expression level of the last encountered type switch case.